### PR TITLE
Updated URL to NodeBots SF

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,7 +161,7 @@ introTitle: Robots powered by JavaScript
     {coords:[   6.23, -75.57], name: "NodeBots Medellín", url: "http://nodebotsmed.tumblr.com/"},
     {coords:[ -33.92,  18.42], name: "NodeBots Cape Town", url: "https://twitter.com/nodebotscpt"},
     {coords:[ -27.47, 153.02], name: "NodeBots Brisbane", url: "http://www.eventbrite.com.au/e/brisbanes-international-nodebots-day-tickets-12120977169"},
-    {coords:[  37.77,-122.41], name: "NodeBots SF", url:"http://lanyrd.com/2013/nodebotssf/"},
+    {coords:[  37.77,-122.41], name: "NodeBots SF", url:"http://www.meetup.com/nodebotssf/"},
     {coords:[  36.85, -76.28], name: "Norfolk.js", url:"http://www.meetup.com/NorfolkJS/events/187172562/"},
     {coords:[  29.76, -95.36], name: "NodeBots Houston, TX", url:"https://ti.to/houstonjs/nodebotsday"},
     {coords:[  36.16,-115.13], name: "NodeBotsLas Vegas, MV (Meowada)", url:""},


### PR DESCRIPTION
Missed a URL update when we switchd to meetup.com for NodeBots SF.
